### PR TITLE
Fix logger creation when showLogs is false

### DIFF
--- a/src/createLogger.js
+++ b/src/createLogger.js
@@ -11,8 +11,8 @@ log.tap = (msg) => res => {
 
 const createLogger = showLogs => {
   if (!showLogs) {
-    const log = function () {};
-    log.tap   = function () {};
+    const log = () => {};
+    log.tap   = () => res => res;
     return log;
   }
 


### PR DESCRIPTION
### Summary
This PR does 2 things:
- Fix warning `Warning: .then() only accepts functions but was passed: [object Undefined]` when `showLogs` is false(details below)
- Correctly flow through the given value in `log.tap`

### Details
I was trying out the plugin in [vue.js webpack template](https://github.com/vuejs-templates/webpack) but got the following warning:

```
(node:452) Warning: .then() only accepts functions but was passed: [object Undefined]
```

<details>
<summary>webpack.dev.conf.js</summary>

```js
var path = require('path');
var utils = require('./utils')
var webpack = require('webpack')
var config = require('../config')
var merge = require('webpack-merge')
var baseWebpackConfig = require('./webpack.base.conf')
var AutoDllPlugin = require('autodll-webpack-plugin')
var HtmlWebpackPlugin = require('html-webpack-plugin')
var FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')

// add hot-reload related code to entry chunks
Object.keys(baseWebpackConfig.entry).forEach(function (name) {
  baseWebpackConfig.entry[name] = ['./build/dev-client'].concat(baseWebpackConfig.entry[name])
})

module.exports = merge(baseWebpackConfig, {
  module: {
    rules: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap })
  },
  // cheap-module-eval-source-map is faster for development
  devtool: '#cheap-module-eval-source-map',
  plugins: [
    new webpack.DefinePlugin({
      'process.env': config.dev.env
    }),
    // https://github.com/glenjamin/webpack-hot-middleware#installation--usage
    new webpack.HotModuleReplacementPlugin(),
    new webpack.NoEmitOnErrorsPlugin(),
    // https://github.com/ampedandwired/html-webpack-plugin
    new HtmlWebpackPlugin({
      filename: 'index.html',
      template: 'index.html',
      inject: true
    }),
    new AutoDllPlugin({
      inject: true,
      context: path.join(__dirname, '..'),
      filename: '[name]_[hash].js',
      path: './dll',
      entry: {
        vendor: [
          'vue',
          'vue-router'
        ]
      }
    }),
    new FriendlyErrorsPlugin()
  ]
})

```

</details>

<br>

<details>
<summary>Stack Trace</summary>

```
(node:2948) Warning: .then() only accepts functions but was passed: [object Undefined]
Warning: .then() only accepts functions but was passed: [object Undefined]
    at compileIfNeeded (E:\Projects\experiments\vue-test\node_modules\autodll-webpack-plugin\lib\compileIfNeeded.js:75:6)
    at Compiler.onRun (E:\Projects\experiments\vue-test\node_modules\autodll-webpack-plugin\lib\plugin.js:84:73)
    at Compiler.applyPluginsAsyncSeries (E:\Projects\experiments\vue-test\node_modules\tapable\lib\Tapable.js:142:13)
    at Watching._go (E:\Projects\experiments\vue-test\node_modules\webpack\lib\Compiler.js:42:16)
    at Watching.<anonymous> (E:\Projects\experiments\vue-test\node_modules\webpack\lib\Compiler.js:33:8)
    at Compiler.readRecords (E:\Projects\experiments\vue-test\node_modules\webpack\lib\Compiler.js:388:10)
    at new Watching (E:\Projects\experiments\vue-test\node_modules\webpack\lib\Compiler.js:30:16)
    at Compiler.watch (E:\Projects\experiments\vue-test\node_modules\webpack\lib\Compiler.js:219:17)
    at Object.startWatch (E:\Projects\experiments\vue-test\node_modules\webpack-dev-middleware\lib\Shared.js:169:29)
    at Shared (E:\Projects\experiments\vue-test\node_modules\webpack-dev-middleware\lib\Shared.js:231:8)
    at module.exports (E:\Projects\experiments\vue-test\node_modules\webpack-dev-middleware\middleware.js:22:15)
    at Object.<anonymous> (E:\Projects\experiments\vue-test\build\dev-server.js:28:54)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Function.Module.runMain (module.js:605:10)
    at startup (bootstrap_node.js:158:16)
```

</details>

<br>

Additionally, `log.tap` logs the given message and passes the result resolved from the promise through to the chain. This was not being done when `showLogs` was false.