### PR TITLE
Set babel target to node 4 instead of current

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "env",
         {
           "targets": {
-            "node": "current"
+            "node": "4"
           }
         }
       ]


### PR DESCRIPTION
Keeping the `babel-preset-env` target as `"current"` means that the generated files depend on the node process version. Instead set target to `"4"` to avoid this issue.

Closes #17.