### PR TITLE
Use make-dir instead of mkdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "del": "^3.0.0",
     "find-cache-dir": "^1.0.0",
     "lodash": "^4.17.4",
+    "make-dir": "^1.0.0",
     "memory-fs": "^0.4.1",
-    "mkdirp": "^0.5.1",
     "webpack": "^3.0.0"
   },
   "devDependencies": {

--- a/src/compileIfNeeded.js
+++ b/src/compileIfNeeded.js
@@ -2,13 +2,13 @@ import path from 'path';
 import isEqual from 'lodash/isEqual';
 import isEmpty from 'lodash/isEmpty';
 import fs from './utils/fs';
-import { mkdirp } from './utils/index.js';
+import makeDir from 'make-dir';
 import { cacheDir } from './paths';
 import createLogger from './createLogger';
 import del from 'del';
 
 const isCacheValid = settings => {
-  return mkdirp(cacheDir)
+  return makeDir(cacheDir)
     .then(() => fs.readFileAsync(path.resolve(cacheDir, 'lastSettings.json')))
     .then(file => {
       let lastSettings = JSON.parse(file);
@@ -42,7 +42,7 @@ export const compile = (settings, getCompiler) => () => {
 
 const compileIfNeeded = (settings, getCompiler) => {
   const log = createLogger(settings.debug);
-      
+
   return isCacheValid(settings)
     .then(log.tap(isValid => `is valid cache? ${isValid}`))
     .then(isValid => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,14 +1,9 @@
-import { promisify } from 'bluebird';
-import _mkdirp from 'mkdirp';
-
-export const mkdirp = promisify(_mkdirp);
 export const concat = Array.prototype.concat.bind([]);
 
 export const merge = (...args) => Object.assign({}, ...args);
 export const keys = Object.keys;
 
 export default {
-  mkdirp,
   concat,
   merge,
   keys


### PR DESCRIPTION
Switch out `mkdirp` in favor of `make-dir`. `make-dir` is promise ready and does not need to be promisified using `bluebird`. More advantages here - https://github.com/sindresorhus/make-dir