### PR TITLE
Fix failing tests for createGetPublicPath on windows(path compare)

### DIFF
--- a/specs/createGetPublicPath.spec.js
+++ b/specs/createGetPublicPath.spec.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import test from 'tape';
 import { createGetPublicPath } from '../src/paths';
 
@@ -7,7 +8,7 @@ test('createGetPublicPath: should return publicPath path currently', (tt) => {
   const filename = 'filename.js';
   const getPublicPath = createGetPublicPath(compilerOptions, dllPath);
 
-  const expected = '/base/dllPath/filename.js';
+  const expected = path.normalize('/base/dllPath/filename.js');
   tt.equals(getPublicPath(filename), expected);
   tt.end();
 });
@@ -18,18 +19,18 @@ test('createGetPublicPath: should return relative path currently when relative =
   const filename = 'filename.js';
   const getPublicPath = createGetPublicPath(compilerOptions, dllPath);
 
-  const expected = 'dllPath/filename.js';
+  const expected = path.normalize('dllPath/filename.js');
   tt.equals(getPublicPath(filename, true), expected);
   tt.end();
 });
 
 test('createGetPublicPath: without compiler.options.publicPath', (t) => {
-  const compilerOptions = { output: {} }; 
+  const compilerOptions = { output: {} };
   const dllPath = './dllPath';
   const filename = 'filename.js';
   const getPublicPath = createGetPublicPath(compilerOptions, dllPath);
 
-  const expected = 'dllPath/filename.js';
+  const expected = path.normalize('dllPath/filename.js');
 
   t.equals(getPublicPath(filename), expected);
   t.end();


### PR DESCRIPTION
Tests for `createGetPublicPath` fail due to difference in path separator for unix and windows:
```
⨯ createGetPublicPath: should return publicPath path currently
  not ok 7 should be equal
    ---
      operator: equal
      expected: '/base/dllPath/filename.js'
      actual:   '\\base\\dllPath\\filename.js'
      at: Test.<anonymous> (E:/Projects/repos/autodll-webpack-plugin/specs/createGetPublicPath.spec.js:11:6)
      stack: |-
        Error: should be equal
            ...
            at Test.<anonymous> (E:/Projects/repos/autodll-webpack-plugin/specs/createGetPublicPath.spec.js:11:6)
            ...
    ...
⨯ createGetPublicPath: should return relative path currently when relative = true
  not ok 8 should be equal
    ---
      operator: equal
      expected: 'dllPath/filename.js'
      actual:   'dllPath\\filename.js'
      at: Test.<anonymous> (E:/Projects/repos/autodll-webpack-plugin/specs/createGetPublicPath.spec.js:22:6)
      stack: |-
        Error: should be equal
            ...
            at Test.<anonymous> (E:/Projects/repos/autodll-webpack-plugin/specs/createGetPublicPath.spec.js:22:6)
            ...
    ...
⨯ createGetPublicPath: without compiler.options.publicPath
  not ok 9 should be equal
    ---
      operator: equal
      expected: 'dllPath/filename.js'
      actual:   'dllPath\\filename.js'
      at: Test.<anonymous> (E:/Projects/repos/autodll-webpack-plugin/specs/createGetPublicPath.spec.js:34:5)
      stack: |-
        Error: should be equal
            ...
            at Test.<anonymous> (E:/Projects/repos/autodll-webpack-plugin/specs/createGetPublicPath.spec.js:34:5)
            ...
```

We can solve this by using [`slash`](https://github.com/sindresorhus/slash) and converting the path returned by `getPublicPath` to unix format before comparing with out expected path.