### PR TITLE
Allow requiring json files

### DIFF
--- a/src/createConfig.js
+++ b/src/createConfig.js
@@ -9,7 +9,7 @@ const createConfig = ({ hash, filename, entry, plugins }) => {
 
   return {
     resolve: {
-      extensions: ['.js', '.jsx']
+      extensions: ['.js', '.jsx', '.json']
     },
     entry: entry,
     output: {


### PR DESCRIPTION
This allows modules in node_modules to include json files
without extension, which some packages do.

The json-loader is on by default as of webpack 2.