### PR TITLE
fix: Slashify createConfig results to match snapshot on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "lint-staged": "^4.0.0",
     "prettier-eslint-cli": "4.4.0",
     "recursive-readdir": "^2.2.1",
+    "slash": "^1.0.0",
     "spy": "^1.0.0",
     "uglifyjs-webpack-plugin": "^0.4.6",
     "webpack": "^3.2.0",

--- a/specs/createConfig.spec.js
+++ b/specs/createConfig.spec.js
@@ -1,8 +1,10 @@
 import test from 'ava';
 import isUndefined from 'lodash/isUndefined';
+import range from 'lodash/range';
 import { _createConfig } from '../src/createConfig';
 import { cacheDir } from './helpers/mocks';
 import createSettingsHelper from './helpers/createSettingsHelper';
+import slashify from './helpers/slashify';
 
 import AutoDllPlugin from '../src';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
@@ -52,6 +54,18 @@ const parentConfig = {
 test('createConfig: basic', t => {
   const settings = settingsHelper({});
   const results = createConfig(settings, {});
+
+  // The config has `path` attributes which vary depending on the OS. One way to deal
+  // with this w.r.t snapshots is snapshot serializers -
+  // https://facebook.github.io/jest/docs/en/configuration.html#snapshotserializers-array-string.
+  // However, to the best of my knowledge, this cannot be used with ava. So the work
+  // around is to manually slashify all the properties which are file paths.
+  slashify(
+    results,
+    ['output.path'].concat(
+      range(0, results.plugins.length).map(idx => `plugins[${idx}].options.path`)
+    )
+  );
   t.snapshot(results);
 });
 

--- a/specs/helpers/slashify.js
+++ b/specs/helpers/slashify.js
@@ -1,0 +1,9 @@
+import slash from 'slash';
+import get from 'lodash/get';
+import set from 'lodash/set';
+
+export default function slashify(obj, propPaths) {
+  propPaths.forEach(propPath => {
+    set(obj, propPath, slash(get(obj, propPath)));
+  });
+}


### PR DESCRIPTION
### Failing test on Windows
```
  createConfig » createConfig: basic
  E:\Projects\repos\autodll-webpack-plugin\specs\createConfig.spec.js:63

   62:   const results = createConfig(settings, {});
   63:   t.snapshot(results);
   64: });

  Did not match snapshot

  Difference:

    {
      context: '/parent_context/',
      entry: Object { … },
      output: {
        filename: '[name].js',
        library: '[name]_[hash]',
  -     path: '\\.cache\\fake-cache-dir\\FAKE_ENV_instance_2_61ae4764b47d4b9f47ec453f102df1e4',
  +     path: '/.cache/fake-cache-dir/FAKE_ENV_instance_2_61ae4764b47d4b9f47ec453f102df1e4',
      },
      plugins: [
        DllPlugin {
          options: {
            name: '[name]_[hash]',
  -         path: '\\.cache\\fake-cache-dir\\FAKE_ENV_instance_2_61ae4764b47d4b9f47ec453f102df1e4\\[name].manifest.json',
  +         path: '/.cache/fake-cache-dir/FAKE_ENV_instance_2_61ae4764b47d4b9f47ec453f102df1e4/[name].manifest.json',
          },
        },
      ],
    }
```

Test failure is due to difference in path on *nix and windows. This PR uses [`slash`](https://github.com/sindresorhus/slash) to convert the path to *nix format before comparing with snapshot.