### PR TITLE
fix: Use `is-windows` for resolving root of `cacheDir`

### DIFF
--- a/specs/createMemory.spec.js
+++ b/specs/createMemory.spec.js
@@ -1,11 +1,12 @@
 import test from 'ava';
 import { _createMemory } from '../src/createMemory';
 import createHash from '../src/createHash';
+import os from 'os';
 import MemoryFileSystem from 'memory-fs';
 import { promisifyAll } from 'bluebird';
 import path from 'path';
 
-const cacheDir = '/my/cache/dir';
+const cacheDir = `${os.tmpdir()}/my/cache/dir`;
 
 // why? testing with the FileSystem is hard.
 // We can't run multiple tests in parallel when using the FS


### PR DESCRIPTION
### Failing test on windows:

```
  createMemory » createMemory should have bundles
  E:\Projects\repos\autodll-webpack-plugin\node_modules\memory-fs\lib\MemoryFileSystem.js:44

  Error thrown in test:

  Error {
    code: 'EINVAL',
    errno: 18,
    message: 'invalid argument',
    path: '\\my\\cache\\dir\\__76a921735ae007e769f230421e799037',
  }

  pathToArray (node_modules/memory-fs/lib/MemoryFileSystem.js:44:10)
  MemoryFileSystem.mkdirpSync (node_modules/memory-fs/lib/MemoryFileSystem.js:139:13)
  createFakeFS (specs/createMemory.spec.js:13:6)
  Test.fn (specs/createMemory.spec.js:28:14)



  createMemory » createMemory should not have bundles
  E:\Projects\repos\autodll-webpack-plugin\node_modules\memory-fs\lib\MemoryFileSystem.js:44

  Error thrown in test:

  Error {
    code: 'EINVAL',
    errno: 18,
    message: 'invalid argument',
    path: '\\my\\cache\\dir\\__95de211ae81b6d586cbe88923384de07',
  }

  pathToArray (node_modules/memory-fs/lib/MemoryFileSystem.js:44:10)
  MemoryFileSystem.mkdirpSync (node_modules/memory-fs/lib/MemoryFileSystem.js:139:13)
  createFakeFS (specs/createMemory.spec.js:13:6)
  Test.fn (specs/createMemory.spec.js:44:14)
```

This PR fixes these errors by using the `is-windows` module to set root as `C:/` on windows and `/` otherwise for `cacheDir`.

Closes #9 
