### PR TITLE
Support URL publicPaths

### DIFF
--- a/specs/paths.spec.js
+++ b/specs/paths.spec.js
@@ -1,0 +1,64 @@
+import test from 'ava';
+import { getInjectPath } from '../src/paths';
+
+test('getInjectPath: should join publicPath and pluginPath slashes correctly', t => {
+  const expectedPath = '/a/b/c.js';
+
+  t.is(
+    getInjectPath({ publicPath: '/a', pluginPath: 'b', filename: 'c.js' }),
+    expectedPath
+  );
+
+  t.is(
+    getInjectPath({ publicPath: '/a/', pluginPath: 'b', filename: 'c.js' }),
+    expectedPath
+  );
+
+  t.is(
+    getInjectPath({ publicPath: '/a', pluginPath: '/b', filename: 'c.js' }),
+    expectedPath
+  );
+
+  t.is(
+    getInjectPath({ publicPath: '/a/', pluginPath: '/b', filename: 'c.js', }),
+    expectedPath
+  );
+});
+
+test('getInjectPath: should handle URL publicPaths', t => {
+  t.is(
+    getInjectPath({
+      publicPath: 'http://example.com',
+      pluginPath: 'a/b/c/d/',
+      filename: 'e.js',
+    }),
+    'http://example.com/a/b/c/d/e.js'
+  );
+
+  t.is(
+    getInjectPath({
+      publicPath: 'localhost',
+      pluginPath: 'a',
+      filename: 'b.js',
+    }),
+    'localhost/a/b.js'
+  );
+
+  t.is(
+    getInjectPath({
+      publicPath: '//localhost:8080',
+      pluginPath: 'a',
+      filename: 'b.js',
+    }),
+    '//localhost:8080/a/b.js'
+  );
+
+  t.is(
+    getInjectPath({
+      publicPath: 'https://localhost:8080',
+      pluginPath: 'a',
+      filename: 'b.js',
+    }),
+    'https://localhost:8080/a/b.js'
+  );
+});

--- a/src/paths.js
+++ b/src/paths.js
@@ -5,3 +5,12 @@ export const cacheDir = findCacheDir({ name: 'autodll-webpack-plugin' });
 
 export const getManifestPath = hash => bundleName =>
   path.resolve(cacheDir, hash, `${bundleName}.manifest.json`);
+
+export const getInjectPath = ({ publicPath, pluginPath, filename }) => {
+  let injectPublicPath = publicPath;
+  let injectRestPath = path.join(pluginPath, filename);
+  // Ensure that injectPublicPath and injectRestPath can be safely concatinated
+  if (!injectPublicPath.endsWith('/')) { injectPublicPath += '/'; }
+  if (injectRestPath.startsWith('/')) { injectRestPath = injectRestPath.substr(1); }
+  return (injectPublicPath + injectRestPath);
+};

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -5,7 +5,7 @@ import { RawSource } from 'webpack-sources';
 
 import path from 'path';
 
-import { cacheDir, getManifestPath } from './paths';
+import { cacheDir, getManifestPath, getInjectPath } from './paths';
 import { concat, merge, keys } from './utils/index.js';
 import createCompileIfNeeded from './createCompileIfNeeded';
 import createConfig from './createConfig';
@@ -103,9 +103,13 @@ class AutoDLLPlugin {
             const dllEntriesPaths = flatMap(
               memory.getStats().entrypoints,
               'assets'
-            ).map((filename) => {
-              return path.join(settings.publicPath, settings.path, filename);
-            });
+            ).map((filename) =>
+              getInjectPath({
+                publicPath: settings.publicPath,
+                pluginPath: settings.path,
+                filename,
+              })
+            );
             
             htmlPluginData.assets.js = concat(
               dllEntriesPaths,


### PR DESCRIPTION
Fixes https://github.com/asfktz/autodll-webpack-plugin/issues/6 https://github.com/asfktz/autodll-webpack-plugin/issues/61  https://github.com/asfktz/autodll-webpack-plugin/issues/66

`examples/recommended/dist/index.html` _before_
![image](https://user-images.githubusercontent.com/2373958/31312643-a0c63c7c-abc8-11e7-9b2f-e29d02f783b1.png)

`examples/recommended/dist/index.html` _after_
![image](https://user-images.githubusercontent.com/2373958/31312645-b0fadf30-abc8-11e7-9a1d-718322e6ca9c.png)

## This PR will
- Make sure `autodll-webpack-plugin` and `html-webpack-plugin` prefix files in the same way when `publicPath` is a URL
- Make sure URL publicPaths are injected correctly into `html-webpack-plugin` assets.

It is sometimes desirable to define webpack's `output.publicPath` as a URL. 
I have a project where the following publicPath is needed during development:

<details><summary><code>webpack.config.js</code></summary><p>

```js
module.exports = {
  // ...
  output: {
    // ...
    publicPath: 'https://localhost:8080',
  },
  // ...
}
```
</p></details>

## Problem and solution

Currently, the `path.join` is mangling the slashed in publicPaths that look like `//localhost`, `https://example.com`, etc.
https://github.com/asfktz/autodll-webpack-plugin/blob/a8b44f732a0732c01657240022ef54296df70329/src/plugin.js#L106-L108

The fix involves removing `publicPath` from the `path.join` and instead concatenate it with `+`