### PR TITLE
Fix integration test script on Windows

### DIFF
--- a/scripts/runIntegrationTests.js
+++ b/scripts/runIntegrationTests.js
@@ -10,7 +10,7 @@ readdirSync(cwd)
   .filter(isDirectory)
   .map(dirname => join(cwd, dirname))
   .forEach(ctx => {
-    spawnSync('node', ['./node_modules/.bin/ava', '--serial', 'specs/*.integration.js'], {
+    spawnSync('npm', ['test'], {
       cwd: ctx,
       shell: true,
       stdio: 'inherit',

--- a/specs/fixtures/basic/package.json
+++ b/specs/fixtures/basic/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
-  "scripts": {},
+  "scripts": {
+    "test": "ava --serial specs/*.integration.js"
+  },
   "devDependencies": {
     "ava": "^0.21.0",
     "axios": "^0.16.2",


### PR DESCRIPTION
If I try to `yarn run test:integration`, this happens:
```
λ yarn run test:integration
yarn run v1.3.2
$ node ./scripts/runIntegrationTests.js
E:\Projects\repos\autodll-webpack-plugin\specs\fixtures\basic\node_modules\.bin\ava:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:152:10)
    at Module._compile (module.js:605:28)
    at Object.Module._extensions..js (module.js:652:10)
    at Module.load (module.js:560:32)
    at tryModuleLoad (module.js:503:12)
    at Function.Module._load (module.js:495:3)
    at Function.Module.runMain (module.js:682:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:613:3
Done in 0.67s.
```

This PR fixes the script but the tests itself are failing. See #81.