### PR TITLE
Propagate process exit code in integration test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
+  - '9'
   - '8'
-  - '7'
   - '6'
-#  - '4'
+  - '4'
 install: npm install
 script:
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: node_js
+
 node_js:
   - '9'
   - '8'
   - '6'
   - '4'
-install: npm install
+
+branches:
+  only:
+    - master
+
+install:
+  - npm install
+  - npm run install:fixturedeps
+
 script:
   - npm run build
   - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # install modules
   - npm install
+  - npm run install:fixturedeps
 
 # Post-install test scripts.
 test_script:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "https://github.com/asfktz/autodll-webpack-plugin",
   "main": "lib/index.js",
   "scripts": {
+    "install:fixturedeps": "node ./scripts/installFixtureDeps.js",
     "lint": "eslint src specs",
     "lint:fix": "npm run lint -- --fix",
     "lint-staged": "lint-staged",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "build:watch": "npm run cleanup && babel src --out-dir lib --watch",
     "prepublishOnly": "npm run build",
     "precommit": "del-cli yarn.lock && lint-staged && npm run test",
-    "format":
-      "prettier-eslint --print-width 100 --trailing-comma es5 --single-quote --write \"{{src,specs,scripts,examples/**/src,experiments/**/src}/**/*.{js,json,css},*.{js,json}}\" "
+    "format": "prettier-eslint --print-width 100 --trailing-comma es5 --single-quote --write \"{{src,specs,scripts,examples/**/src,experiments/**/src}/**/*.{js,json,css},*.{js,json}}\" "
   },
-  "files": ["src", "lib"],
+  "files": [
+    "src",
+    "lib"
+  ],
   "lint-staged": {
     "{{src,specs,scripts,examples/**/src,experiments/**/src}/**/*.{js,json,css},*.{js,json}}": [
       "prettier-eslint --print-width 100 --trailing-comma es5 --single-quote --write",
@@ -34,10 +36,10 @@
     "webpack": ">= 2.0.0"
   },
   "dependencies": {
+    "bluebird": "^3.5.0",
     "del": "^3.0.0",
     "find-cache-dir": "^1.0.0",
     "lodash": "^4.17.4",
-    "bluebird": "^3.5.0",
     "make-dir": "^1.0.0",
     "memory-fs": "^0.4.1",
     "mkdirp": "^0.5.1",
@@ -69,7 +71,8 @@
     "spy": "^1.0.0",
     "uglifyjs-webpack-plugin": "^0.4.6",
     "webpack": "^3.2.0",
-    "webpack-dev-server": "^2.7.1"
+    "webpack-dev-server": "^2.7.1",
+    "write-pkg": "^3.1.0"
   },
   "babel": {
     "presets": [
@@ -102,10 +105,14 @@
   },
   "ava": {
     "files": [],
-    "source": ["src/**/*.js"],
+    "source": [
+      "src/**/*.js"
+    ],
     "concurrency": 5,
     "failFast": false,
-    "require": ["babel-register"],
+    "require": [
+      "babel-register"
+    ],
     "babel": "inherit"
   }
 }

--- a/scripts/getFixtures.js
+++ b/scripts/getFixtures.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const fixturesFldr = path.join(__dirname, '../specs/fixtures');
+
+const isDirectory = fp => fs.lstatSync(fp).isDirectory();
+
+/**
+ * Gets the list of integration test directories. The file paths are absolute.
+ *
+ * @returns Array<string> directories list.
+ */
+module.exports = function getFixtures() {
+  return fs
+    .readdirSync(fixturesFldr)
+    .map(name => path.join(fixturesFldr, name))
+    .filter(isDirectory);
+};

--- a/scripts/installFixtureDeps.js
+++ b/scripts/installFixtureDeps.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const spawnSync = require('child_process').spawnSync;
+const path = require('path');
+const getFixtures = require('./getFixtures');
+
+getFixtures().forEach(fixtureDir => {
+  const result = spawnSync('npm', ['install'], {
+    cwd: fixtureDir,
+    shell: true,
+    stdio: 'inherit',
+  });
+
+  if (result.status !== 0) {
+    const testname = path.basename(fixtureDir);
+    throw new Error(`Failed to install deps for ${testname}`);
+  }
+});

--- a/scripts/runIntegrationTests.js
+++ b/scripts/runIntegrationTests.js
@@ -2,34 +2,28 @@
 
 const spawnSync = require('child_process').spawnSync;
 const path = require('path');
-const fs = require('fs');
+const getFixtures = require('./getFixtures');
 
-const cwd = path.join(__dirname, '../specs/fixtures');
-
-const isDirectory = source => fs.lstatSync(path.join(cwd, source)).isDirectory();
-
-const failingTests = fs
-  .readdirSync(cwd)
-  .filter(isDirectory)
-  .filter(dirname => {
-    const result = spawnSync('npm', ['test'], {
-      cwd: path.join(cwd, dirname),
-      shell: true,
-      stdio: 'inherit',
-    });
-
-    if (result.status !== 0) {
-      console.error(`\nIntegration test for "${dirname}" returned status code ${result.status}!`);
-      return true;
-    }
-    return false;
+const failingTests = getFixtures().filter(fixtureDir => {
+  const result = spawnSync('npm', ['test'], {
+    cwd: fixtureDir,
+    shell: true,
+    stdio: 'inherit',
   });
+
+  if (result.status !== 0) {
+    const testname = path.basename(fixtureDir);
+    console.error(`\nIntegration test for "${testname}" returned status code ${result.status}!`);
+    return true;
+  }
+  return false;
+});
 
 if (failingTests.length !== 0) {
   console.error('\nIntegration tests are failing!');
   console.error('The following tests returned non-zero status code:');
   failingTests.forEach(t => {
-    console.error(`  - ${t}`);
+    console.error(`  - ${path.basename(t)}`);
   });
   process.exitCode = 1;
 }

--- a/specs/helpers/integration/createRunner.js
+++ b/specs/helpers/integration/createRunner.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 
 const PORT = 8085;

--- a/specs/helpers/integration/index.js
+++ b/specs/helpers/integration/index.js
@@ -1,22 +1,24 @@
+'use strict';
+
 const createRunner = require('./createRunner');
 const routeCalls = require('./routeCalls');
 
-const { promisifyAll } = require('bluebird');
+const promisifyAll = require('bluebird').promisifyAll;
 const fs = promisifyAll(require('fs'));
 
 const del = require('del');
-const { join } = require('path');
+const path = require('path');
 
 const createClearCache = cwd => () => {
-  const path = join(cwd, '../node_modules/.cache/autodll-webpack-plugin');
-  del.sync(path);
+  const cachePath = path.join(cwd, '../node_modules/.cache/autodll-webpack-plugin');
+  del.sync(cachePath);
 };
 
 const writePkg = require('write-pkg');
 const readPkg = require('read-pkg');
 
 const createPkgHandler = __dirname => {
-  const cwd = join(__dirname, '..');
+  const cwd = path.join(__dirname, '..');
   const originalPkg = readPkg.sync(cwd);
 
   return {
@@ -39,11 +41,12 @@ const createPkgHandler = __dirname => {
 const createMakeChange = (cwd, filepath) => change => {
   if (!filepath) throw new Error('filepath is required');
 
-  const path = join(cwd, filepath);
-  return fs.writeFileAsync(path, `module.exports = '${change}';`);
+  return fs.writeFileAsync(path.join(cwd, filepath), `module.exports = '${change}';`);
 };
 
-const merge = (...sources) => Object.assign({}, ...sources);
+function merge() {
+  return Object.assign.apply(Object, [{}].concat(Array.from(arguments)));
+}
 
 module.exports = {
   createRunner,

--- a/specs/helpers/integration/routeCalls.js
+++ b/specs/helpers/integration/routeCalls.js
@@ -1,11 +1,14 @@
-const routeCalls = (...callbacks) => {
+'use strict';
+
+function routeCalls() {
+  const callbacks = Array.from(arguments);
   let i = 0;
 
-  return (...args) => {
+  return function() {
     const callback = callbacks[i] || callbacks[callbacks.length - 1];
-    callback(...args);
-    i = i + 1;
+    callback.apply(null, Array.from(arguments));
+    i++;
   };
-};
+}
 
 module.exports = routeCalls;


### PR DESCRIPTION
I noticed that even though the integration test failed, the pre-commit hook did not fail. The status code returned by the child process was not being propagated. So this PR does the following:
- If any tests(right now only 'basic') fail, the script exits with exit code 1.
- Adds some logging.
- Makes the script and helpers node 4 compatible. Since we wouldn't be developing on node 4, testing it on CI is a good idea.
- Tweak travis config:
  - Test on node 4, 9.
  - Stop testing on node 7.
