### PR TITLE
Keep absolute path if needed

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -10,7 +10,7 @@ export const getInjectPath = ({ publicPath, pluginPath, filename }) => {
   let injectPublicPath = publicPath;
   let injectRestPath = path.posix.join(pluginPath, filename);
   // Ensure that injectPublicPath and injectRestPath can be safely concatinated
-  if (!injectPublicPath.endsWith('/')) {
+  if (injectPublicPath && !injectPublicPath.endsWith('/')) {
     injectPublicPath += '/';
   }
   if (injectRestPath.startsWith('/')) {


### PR DESCRIPTION
Hey, I had an issue with this plugin since I wanted the injected DLL files to have an absolute path.
Basically this was emitted :
```html
  <body>
  <script type="text/javascript" src="/vendor_ff08e56269c458a507fa.js"></script><script type="text/javascript" src="main.js"></script></body>
```

and I wanted this:
```html
  <body>
  <script type="text/javascript" src="vendor_ff08e56269c458a507fa.js"></script><script type="text/javascript" src="main.js"></script></body>
```

This PR fixes this issue, however I'm not sure if it would open others.