### PR TITLE
Prevented source maps from being injected into html

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -109,21 +109,26 @@ class AutoDLLPlugin {
     });
 
     if (inject) {
+      const getDllEntriesPaths = extension =>
+        flatMap(memory.getStats().entrypoints, 'assets')
+          .filter(filename => filename.endsWith(extension))
+          .map(filename =>
+            getInjectPath({
+              publicPath: settings.publicPath,
+              pluginPath: settings.path,
+              filename,
+            })
+          );
+
       compiler.plugin('compilation', compilation => {
         compilation.plugin(
           'html-webpack-plugin-before-html-generation',
           (htmlPluginData, callback) => {
-            const dllEntriesPaths = flatMap(memory.getStats().entrypoints, 'assets')
-              .filter(filename => !filename.endsWith('.js.map'))
-              .map(filename =>
-                getInjectPath({
-                  publicPath: settings.publicPath,
-                  pluginPath: settings.path,
-                  filename,
-                })
-              );
-
-            htmlPluginData.assets.js = concat(dllEntriesPaths, htmlPluginData.assets.js);
+            htmlPluginData.assets.js = concat(getDllEntriesPaths('.js'), htmlPluginData.assets.js);
+            htmlPluginData.assets.css = concat(
+              getDllEntriesPaths('.css'),
+              htmlPluginData.assets.css
+            );
 
             callback(null, htmlPluginData);
           }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -113,13 +113,15 @@ class AutoDLLPlugin {
         compilation.plugin(
           'html-webpack-plugin-before-html-generation',
           (htmlPluginData, callback) => {
-            const dllEntriesPaths = flatMap(memory.getStats().entrypoints, 'assets').map(filename =>
-              getInjectPath({
-                publicPath: settings.publicPath,
-                pluginPath: settings.path,
-                filename,
-              })
-            );
+            const dllEntriesPaths = flatMap(memory.getStats().entrypoints, 'assets')
+              .filter(filename => !filename.endsWith('.js.map'))
+              .map(filename =>
+                getInjectPath({
+                  publicPath: settings.publicPath,
+                  pluginPath: settings.path,
+                  filename,
+                })
+              );
 
             htmlPluginData.assets.js = concat(dllEntriesPaths, htmlPluginData.assets.js);
 


### PR DESCRIPTION
Currently if source maps are configured for dll bundle they got injected into html:
![2](https://user-images.githubusercontent.com/1745378/33822885-3256856a-de6a-11e7-9013-2ab36312fbfc.png)

As reproduction you can check https://github.com/WiseBird/auto_dll_source_maps/tree/source_maps_test (note this is a branch)
* `npm i`
* `npm run start:dll`

This PR filters them out by file name.