### PR TITLE
Fix dll assets not found after first watchRun

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -87,7 +87,7 @@ class AutoDLLPlugin {
           compiler.hooks.autodllStatsRetrieved.call(stats, source);
 
           if (source === 'memory') return;
-          memory.sync(settings.hash, stats);
+          return memory.sync(settings.hash, stats);
         })
         .then(() => {
           attachDllReferencePlugin(compiler);


### PR DESCRIPTION
memory.sync is an async function, if we don't return it, it might sync dll assets' source after emit hook.