### PR TITLE
 增加对小程序项目的适配 

### DIFF
--- a/examples/recommended/package.json
+++ b/examples/recommended/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "html-webpack-plugin": "3.2.0",
     "webpack": "^4.0.0",
-    "webpack-cli": "^2.0.11",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
目前现状： 不适用于小程序，打包出来的变量声明为：var [name]_[hash] = function(){}
我的改动：
1. 增加一个配置属性，libraryTarget：'global', 目的是为了暴露出的变量挂载到全局的global对象当中
2. 增加一个额外的配置选项：globalObject: 'global' ,原因是单纯设置libraryTarget : 'global' 会将对象挂载到 window
修改文件路径：`src/createConfig.js`
----
顺带修复recommended demo的webpack-cli 版本过低会运行出错的问题